### PR TITLE
NIX_PATH tip in home manager installation docs

### DIFF
--- a/docs/manual/installation/standalone.md
+++ b/docs/manual/installation/standalone.md
@@ -35,8 +35,14 @@
 
     Once finished, Home Manager should be active and available in your
     user environment.
+    
+::: {.tip}
+If you are running into issues here and added the channel as a user, try
+including `-I ~/.nix-defexpr/channels/` at the end of the command. Your
+`$NIX_PATH` may not include `~/.nix-defexpr/channels`.
+:::
 
-4.  If you do not plan on having Home Manager manage your shell
+5.  If you do not plan on having Home Manager manage your shell
     configuration then you must source the
 
     ``` bash


### PR DESCRIPTION
I kept running into this issue where after nix-channel --add, my the next step of running nix-shell '<home-manager'> would not run since ~/.nix-defexpr/channels wasn't in my $NIX_PATH (on a fairly fresh nixos install). Thought it might help to add it to the docs.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
